### PR TITLE
fix: missing await in guest cart retrieval

### DIFF
--- a/OnlineStoreWeb/Middleware/GuestCartMiddleware.cs
+++ b/OnlineStoreWeb/Middleware/GuestCartMiddleware.cs
@@ -23,7 +23,7 @@ public class GuestCartMiddleware : IMiddleware
             {
                 CreateGuestCartIdCookie(context, cookieName, cartIdstr);
 
-                var cart = _guestCartService.GetCartAsync(cartId);
+                var cart = await _guestCartService.GetCartAsync(cartId);
                 if (cart != null)
                 {
                     await _guestCartService.TouchAsync(cartId);


### PR DESCRIPTION
Added missing 'await' when calling GetCartAsync in GuestCartMiddleware to ensure the cart is properly retrieved asynchronously.